### PR TITLE
Export compiled binary by default

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -17,6 +17,11 @@ jobs:
       
     - name: make bin/app
       run: make bin/app
+    - name: 'export binary'
+      uses: actions/upload-artifact@v2
+      with:
+          name: app
+          path: bin/app
     - name: make clean
       run: make clean
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,6 +21,11 @@ jobs:
 
     - name: make bin/app
       run: make bin/app
+    - name: 'export binary'
+      uses: actions/upload-artifact@v2
+      with:
+          name: app
+          path: bin/app
     - name: make clean
       run: make clean
       

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,6 +21,12 @@ jobs:
       run: mingw32-make bin/app
       shell: cmd
       
+    - name: 'export binary'
+      uses: actions/upload-artifact@v2
+      with:
+          name: app
+          path: bin/app.exe
+      
     - name: make clean
       run: mingw32-make clean
       shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
     - name: 'export binary'
       uses: actions/upload-artifact@v2
       with:
-          name: app
+          name: app.exe
           path: bin/app.exe
       
     - name: make clean

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ It's pretty simple actually:
 ### Contributors
 - [J-Mo63](https://github.com/J-Mo63) Jonathan Moallem - co-creator, maintainer
 - [Raelr](https://github.com/Raelr) Aryeh Zinn - co-creator, maintainer
+- [mTvare6](https://github.com/mTvare6) mTvare6 - contributor
 
 ## Licence
 


### PR DESCRIPTION
It makes sense to export binaries just in case, nothing goes waste here as github just have to export a single binary.
This makes sense when a single dev wants to compile his game so it can run on other devices.