### PR TITLE
fix: Updates raylib-cpp submodule to current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ It's pretty simple actually:
 - [J-Mo63](https://github.com/J-Mo63) Jonathan Moallem - co-creator, maintainer
 - [Raelr](https://github.com/Raelr) Aryeh Zinn - co-creator, maintainer
 - [mTvare6](https://github.com/mTvare6) mTvare6 - contributor
+- [rafaeldelboni](https://github.com/rafaeldelboni) Rafael Delboni - contributor
 
 ## Licence
 


### PR DESCRIPTION
This repo was pointing to an old commit in raylib-ccp which leads to use Raylib v3.1

With this it compiles using Raylib v3.7
```
bin/app
INFO: Initializing raylib 3.7
...
```