### PR TITLE
Upgrade GitHub Actions versions, cleaned up workflow files

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -12,20 +12,24 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+
     - name: make setup
       run: make setup
       
     - name: make bin/app
       run: make bin/app
-    - name: 'export binary'
-      uses: actions/upload-artifact@v2
+
+    - name: export binary
+      uses: actions/upload-artifact@v4
       with:
           name: app
           path: bin/app
+
     - name: make clean
       run: make clean
 
     - name: make bin/app CXX=g++
       run: make bin/app CXX=g++
+    
     - name: make clean
       run: make clean

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,24 +12,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
     - name: update apt
       run: sudo apt-get update
+
     - name: install raylib dependencies
       run: sudo apt install libasound2-dev mesa-common-dev libx11-dev libxrandr-dev libxi-dev xorg-dev libgl1-mesa-dev libglu1-mesa-dev
+
     - name: make setup
       run: make setup
 
     - name: make bin/app
       run: make bin/app
+
     - name: 'export binary'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
           name: app
           path: bin/app
+
     - name: make clean
       run: make clean
       
     - name: make bin/app CXX=g++
       run: make bin/app CXX=g++
+    
     - name: make clean
       run: make clean

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,8 +21,8 @@ jobs:
       run: mingw32-make bin/app
       shell: cmd
       
-    - name: 'export binary'
-      uses: actions/upload-artifact@v2
+    - name: export binary
+      uses: actions/upload-artifact@v4
       with:
           name: app.exe
           path: bin/app.exe

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ include
 lib
 bin
 .idea
+.DS_Store


### PR DESCRIPTION
This PR cleans up the Actions workflow files and upgrades the actions version for `actions/upload-artifact` from deprecated `v2` to `v4`.